### PR TITLE
Add Python packaging support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,8 @@ jobs:
         python-version: '3.11'
         channels: conda-forge
         channel-priority: strict
+        conda-remove-defaults: true
+        activate-environment: build-env
         
     - name: Install NEST Simulator
       shell: bash -l {0}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
         # Install the built package
         pip install PyNEST/dist/*.whl
         # Test NEST availability
-        python -c "import nest; print(f'NEST version: {nest.version()}')"
+        python -c "import nest; print(f'NEST version: {nest.__version__}')"
         # Test import
         python -c "import microcircuit; print(f'Successfully imported microcircuit version {microcircuit.__version__}')"
       

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,19 +17,46 @@ jobs:
       with:
         python-version: '3.x'
         
+    - name: Setup Miniconda
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        auto-update-conda: true
+        python-version: '3.x'
+        channels: conda-forge
+        channel-priority: strict
+        
+    - name: Install NEST Simulator
+      shell: bash -l {0}
+      run: |
+        conda install -c conda-forge nest-simulator
+        
     - name: Install build dependencies
+      shell: bash -l {0}
       run: |
         python -m pip install --upgrade pip
         pip install build twine
         
     - name: Build package
+      shell: bash -l {0}
       run: python -m build
       working-directory: ./PyNEST
       
     - name: Check package
+      shell: bash -l {0}
       run: python -m twine check PyNEST/dist/*
       
+    - name: Test package before publishing
+      shell: bash -l {0}
+      run: |
+        # Install the built package
+        pip install PyNEST/dist/*.whl
+        # Test NEST availability
+        python -c "import nest; print(f'NEST version: {nest.version()}')"
+        # Test import
+        python -c "import microcircuit; print(f'Successfully imported microcircuit version {microcircuit.__version__}')"
+      
     - name: Publish to PyPI
+      shell: bash -l {0}
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,23 +12,18 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
-        
     - name: Setup Miniconda
       uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
-        python-version: '3.x'
+        python-version: '3.11'
         channels: conda-forge
         channel-priority: strict
         
     - name: Install NEST Simulator
       shell: bash -l {0}
       run: |
-        conda install -c conda-forge nest-simulator
+        conda install -c conda-forge nest-simulator -y
         
     - name: Install build dependencies
       shell: bash -l {0}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+        
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+        
+    - name: Build package
+      run: python -m build
+      working-directory: ./PyNEST
+      
+    - name: Check package
+      run: python -m twine check PyNEST/dist/*
+      
+    - name: Publish to PyPI
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        python -m twine upload PyNEST/dist/* --verbose

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -1,0 +1,52 @@
+name: Test Publish to TestPyPI
+
+on:
+  # Trigger on pushes to main branch
+  push:
+    branches: [ main, add-packaging ]
+  # Trigger on pull requests
+  pull_request:
+    branches: [ main ]
+  # Manual trigger
+  workflow_dispatch:
+
+jobs:
+  test-publish:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+        
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+        
+    - name: Build package
+      run: python -m build
+      working-directory: ./PyNEST
+      
+    - name: Check package
+      run: python -m twine check PyNEST/dist/*
+      
+    - name: Publish to TestPyPI
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.TESTPYPI_API_TOKEN }}
+      run: |
+        python -m twine upload --repository testpypi PyNEST/dist/* --verbose
+        
+    - name: Test installation from TestPyPI
+      run: |
+        # Wait a bit for TestPyPI to process the upload
+        sleep 30
+        # Install from TestPyPI
+        pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ microcircuit-pd14
+        # Test import
+        python -c "import microcircuit; print(f'Successfully imported microcircuit version {microcircuit.__version__}')"

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -25,6 +25,8 @@ jobs:
         python-version: '3.11'
         channels: conda-forge
         channel-priority: strict
+        conda-remove-defaults: true
+        activate-environment: test-env
         
     - name: Install NEST Simulator
       shell: bash -l {0}

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -23,19 +23,36 @@ jobs:
       with:
         python-version: '3.x'
         
+    - name: Setup Miniconda
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        auto-update-conda: true
+        python-version: '3.x'
+        channels: conda-forge
+        channel-priority: strict
+        
+    - name: Install NEST Simulator
+      shell: bash -l {0}
+      run: |
+        conda install -c conda-forge nest-simulator
+        
     - name: Install build dependencies
+      shell: bash -l {0}
       run: |
         python -m pip install --upgrade pip
         pip install build twine
         
     - name: Build package
+      shell: bash -l {0}
       run: python -m build
       working-directory: ./PyNEST
       
     - name: Check package
+      shell: bash -l {0}
       run: python -m twine check PyNEST/dist/*
       
     - name: Publish to TestPyPI
+      shell: bash -l {0}
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.TESTPYPI_API_TOKEN }}
@@ -43,10 +60,13 @@ jobs:
         python -m twine upload --repository testpypi PyNEST/dist/* --verbose
         
     - name: Test installation from TestPyPI
+      shell: bash -l {0}
       run: |
         # Wait a bit for TestPyPI to process the upload
         sleep 30
         # Install from TestPyPI
         pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ microcircuit-pd14
+        # Test NEST availability
+        python -c "import nest; print(f'NEST version: {nest.version()}')"
         # Test import
         python -c "import microcircuit; print(f'Successfully imported microcircuit version {microcircuit.__version__}')"

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -62,6 +62,6 @@ jobs:
         # Install from TestPyPI
         pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ microcircuit-pd14
         # Test NEST availability
-        python -c "import nest; print(f'NEST version: {nest.version()}')"
+        python -c "import nest; print(f'NEST version: {nest.__version__}')"
         # Test import
         python -c "import microcircuit; print(f'Successfully imported microcircuit version {microcircuit.__version__}')"

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -18,23 +18,18 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
-        
     - name: Setup Miniconda
       uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
-        python-version: '3.x'
+        python-version: '3.11'
         channels: conda-forge
         channel-priority: strict
         
     - name: Install NEST Simulator
       shell: bash -l {0}
       run: |
-        conda install -c conda-forge nest-simulator
+        conda install -c conda-forge nest-simulator -y
         
     - name: Install build dependencies
       shell: bash -l {0}

--- a/PyNEST/MANIFEST.in
+++ b/PyNEST/MANIFEST.in
@@ -1,0 +1,25 @@
+# Include the README
+include README.md
+
+# Include the license
+include ../LICENSES/GPL-2.0-or-later.txt
+
+# Include documentation
+recursive-include docs *.md *.rst *.txt
+
+# Include examples
+recursive-include examples *.py *.yaml *.yml *.json
+
+# Include reference data
+recursive-include reference_data *.py *.dat *.txt *.csv
+
+# Include tests
+recursive-include tests *.py
+
+# Exclude compiled files
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude *.pyd
+global-exclude __pycache__
+global-exclude .git*
+global-exclude .DS_Store

--- a/PyNEST/pyproject.toml
+++ b/PyNEST/pyproject.toml
@@ -22,7 +22,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 [project]
-name = "microcircuit-pd14"
+name = "microcircuit"
 description = "PyNEST implementation of the cortical microcircuit model of Potjans & Diesmann (2014)."
 dynamic = ["version"]
 readme = "README.md"

--- a/PyNEST/pyproject.toml
+++ b/PyNEST/pyproject.toml
@@ -22,13 +22,26 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 [project]
-name = "microcircuit"
+name = "microcircuit-pd14"
 description = "PyNEST implementation of the cortical microcircuit model of Potjans & Diesmann (2014)."
-version = "0.1.0"
+dynamic = ["version"]
 readme = "README.md"
+license = {text = "GPL-2.0-or-later"}
 authors = [
     { name = "Tom Tetzlaff", email = "t.tetzlaff@fz-juelich.de" },
     { name = "Johanna Senk", email = "j.senk@fz-juelich.de" }    
+]
+maintainers = [
+    { name = "Tom Tetzlaff", email = "t.tetzlaff@fz-juelich.de" },
+    { name = "Johanna Senk", email = "j.senk@fz-juelich.de" }    
+]
+keywords = [
+    "neuroscience",
+    "computational neuroscience", 
+    "cortical microcircuit",
+    "NEST simulator",
+    "neural networks",
+    "brain modeling"
 ]
 
 requires-python = ">=3.8"
@@ -38,7 +51,41 @@ dependencies = [
     # "nest-simulator",   ## needs `pip install nest-simulator` to become available    
     "numpy",
     "psutil",
-    "ruamel.yaml",
+    "ruamel.yaml"
+]
+
+[metadata]
+description-file = "README.md"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Topic :: Software Development :: Libraries :: Python Modules"
+]
+
+[project.urls]
+"Homepage" = "https://github.com/INM-6/microcircuit-PD14-model"
+"Documentation" = "https://github.com/INM-6/microcircuit-PD14-model/blob/main/README.md"
+"Repository" = "https://github.com/INM-6/microcircuit-PD14-model"
+"Bug Tracker" = "https://github.com/INM-6/microcircuit-PD14-model/issues"
+"Changelog" = "https://github.com/INM-6/microcircuit-PD14-model/releases"
+
+[project.scripts]
+#run_microcircuit = "microcircuit.run_microcircuit:main"
+microcircuit = "microcircuit.__main__:main"
+
+[project.optional-dependencies]
+test = [
     "pydocstyle",
     "pylint",
     "pytest",
@@ -50,25 +97,6 @@ dependencies = [
     "pytest-pylint",
     "pytest-xdist",
 ]
-
-[metadata]
-description-file = "README.md"
-classifiers = [
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: GPL-2.0-or-later",
-    "Programming Language :: Python :: 3",
-    "Topic :: Software Development :: Libraries :: Python Modules"
-]
-
-[project.urls]
-"Homepage" = "https://github.com/INM-6/microcircuit-PD14-model"
-"Bug Tracker" = "https://github.com/INM-6/microcircuit-PD14-model/issues"
-
-[project.scripts]
-#run_microcircuit = "microcircuit.run_microcircuit:main"
-microcircuit = "microcircuit.__main__:main"
-
-[project.optional-dependencies]
 dev = [
     "black",
     "bump2version",
@@ -96,3 +124,6 @@ doc = [
 [build-system]
 build-backend = "flit_core.buildapi"
 requires = ["flit_core >=3.2,<4"]
+
+[tool.flit.module]
+name = "microcircuit"

--- a/PyNEST/src/microcircuit/__init__.py
+++ b/PyNEST/src/microcircuit/__init__.py
@@ -27,7 +27,7 @@ PyNEST implementation of the cortical microcircuit model of Potjans & Diesmann (
 Add a longer description here.
 '''
 
-__version__ = '0.1.0'
+__version__ = '0.1.0.dev0'
 __author__ = 'Tom Tetzlaff, Johanna Senk <t.tetzlaff@fz-juelich.de, j.senk@fz-juelich.de>'
 
 from microcircuit.network import Network

--- a/PyNEST/src/microcircuit/__init__.py
+++ b/PyNEST/src/microcircuit/__init__.py
@@ -27,7 +27,7 @@ PyNEST implementation of the cortical microcircuit model of Potjans & Diesmann (
 Add a longer description here.
 '''
 
-__version__ = '0.1.2'
+__version__ = '0.1.0'
 __author__ = 'Tom Tetzlaff, Johanna Senk <t.tetzlaff@fz-juelich.de, j.senk@fz-juelich.de>'
 
 from microcircuit.network import Network

--- a/PyNEST/src/microcircuit/__init__.py
+++ b/PyNEST/src/microcircuit/__init__.py
@@ -27,7 +27,7 @@ PyNEST implementation of the cortical microcircuit model of Potjans & Diesmann (
 Add a longer description here.
 '''
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 __author__ = 'Tom Tetzlaff, Johanna Senk <t.tetzlaff@fz-juelich.de, j.senk@fz-juelich.de>'
 
 from microcircuit.network import Network

--- a/PyNEST/src/microcircuit/__init__.py
+++ b/PyNEST/src/microcircuit/__init__.py
@@ -27,7 +27,7 @@ PyNEST implementation of the cortical microcircuit model of Potjans & Diesmann (
 Add a longer description here.
 '''
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 __author__ = 'Tom Tetzlaff, Johanna Senk <t.tetzlaff@fz-juelich.de, j.senk@fz-juelich.de>'
 
 from microcircuit.network import Network


### PR DESCRIPTION
- Add pyproject.toml with flit_core build system
- Set up GitHub Actions for TestPyPI publishing
- Prepare GitHub Actions for PyPI publishing

Ready for PyPI release.

## Install from TestPyPI

```bash
# Install the package
pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ microcircuit
```

**Note**: Requires `nest-simulator` to be installed separately:

## Install with Optional Dependencies

```bash
# Install package with test dependencies
pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "microcircuit[test]"
```

## Install with All Optional Dependencies (test, dev, doc)

```bash
# Install all optional dependencies (test, dev, doc)
pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "microcircuit[test,dev,doc]"
```
