### PR TITLE
Add README to examples

### DIFF
--- a/PyNEST/examples/README.md
+++ b/PyNEST/examples/README.md
@@ -1,0 +1,2 @@
+# Examples using Cortical Microcircuit Model
+


### PR DESCRIPTION
This is required for sphinx-gallery to build the Python examples