### PR TITLE
Change CSS to improve table headers in Read the Docs

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -22,7 +22,7 @@ a.md-tabs__link, a.md-source {
  }
 
 .md-typeset table:not([class]) th {
-  background-color: #fff;
+  background-color: #ededed;
   color: black;
 }
 .md-typeset table:not([class]) th {

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -23,6 +23,11 @@ a.md-tabs__link, a.md-source {
 
 .md-typeset table:not([class]) th {
   background-color: #fff;
+  color: black;
+}
+.md-typeset table:not([class]) th {
+	/* color: #fff; */
+	vertical-align: top;
 }
 
 /* To add matching styling for the header in index.html */

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -25,10 +25,6 @@ a.md-tabs__link, a.md-source {
   background-color: #ededed;
   color: black;
 }
-.md-typeset table:not([class]) th {
-	/* color: #fff; */
-	vertical-align: top;
-}
 
 /* To add matching styling for the header in index.html */
 div[role="main"] .md-header {


### PR DESCRIPTION
CSS font colour was the same as background in table headers, so the CSS is now changed so the headers are light grey background with black text.