### PR TITLE
Separate the image path on Read the Docs from GitHub for README

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,21 +8,21 @@ build:
   tools:
     python: "3.12"
   jobs:
+    pre_build:
+      # Copy figures to the appropriate directory within docs
+      - mkdir -p docs/_static/images
+      - cp -r figures/* docs/_static/images/
+      # Replace GitHub paths with Sphinx paths in README.md
+      - sed -i 's|figures/|source/images/|g' README.md
     build:
-      pdf:
+     pdf:
         - echo "building pdf $READTHEDOCS_OUTPUT"
         - sed -i "s|{figures/|{docs/model_description/figures/|g" docs/model_description/ModelDescription_microcircuit-PD14-model.tex
         - pdflatex -interaction=nonstopmode -recorder --jobname="microcircuit-pd14-model"  "docs/model_description/ModelDescription_microcircuit-PD14-model.tex"
         - pdflatex -interaction=nonstopmode -recorder --jobname="microcircuit-pd14-model"  "docs/model_description/ModelDescription_microcircuit-PD14-model.tex"
         - cp microcircuit-pd14-model.pdf _readthedocs/html/_static/
         - ls _readthedocs/html/_static
-      pre_build:
-        # Copy figures to the appropriate directory within docs
-        - mkdir -p docs/_static/images
-        - cp -r figures/* docs/_static/images/
-        # Replace GitHub paths with Sphinx paths in README.md
-        - sed -i 's|figures/|source/images/|g' README.md
-sphinx:
+ sphinx:
   builder: html
   configuration: docs/conf.py
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,7 +22,7 @@ build:
         - pdflatex -interaction=nonstopmode -recorder --jobname="microcircuit-pd14-model"  "docs/model_description/ModelDescription_microcircuit-PD14-model.tex"
         - cp microcircuit-pd14-model.pdf _readthedocs/html/_static/
         - ls _readthedocs/html/_static
- sphinx:
+sphinx:
   builder: html
   configuration: docs/conf.py
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,6 +16,12 @@ build:
         - pdflatex -interaction=nonstopmode -recorder --jobname="microcircuit-pd14-model"  "docs/model_description/ModelDescription_microcircuit-PD14-model.tex"
         - cp microcircuit-pd14-model.pdf _readthedocs/html/_static/
         - ls _readthedocs/html/_static
+      pre_build:
+        # Copy figures to the appropriate directory within docs
+        - mkdir -p docs/_static/images
+        - cp -r figures/* docs/_static/images/
+        # Replace GitHub paths with Sphinx paths in README.md
+        - sed -i 's|figures/|source/images/|g' README.md
 sphinx:
   builder: html
   configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
       - mkdir -p docs/_static/images
       - cp -r figures/* docs/_static/images/
       # Replace GitHub paths with Sphinx paths in README.md
-      - sed -i 's|figures/|source/images/|g' README.md
+      - sed -i "s|figures/|source/images/|g" README.md
     build:
      pdf:
         - echo "building pdf $READTHEDOCS_OUTPUT"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
       - mkdir -p docs/_static/images
       - cp -r figures/* docs/_static/images/
       # Replace GitHub paths with Sphinx paths in README.md
-      - sed -i "s|figures/|source/images/|g" README.md
+      - sed -i "s|figures/|_static/images/|g" README.md
     build:
      pdf:
         - echo "building pdf $READTHEDOCS_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Specifically, the model demonstrates that the observed cell-type and layer speci
 
 |  |  |  |
 |--|--|--|
-| <img src="https://microcircuit-pd14-model.readthedocs.io/en/latest/_images/potjans_2014_microcircuit.png" width="300"/> | <img src="https://microcircuit-pd14-model.readthedocs.io/en/latest/_images/potjans_2014_raster_plot.png" width="400"/> | <img src="https://microcircuit-pd14-model.readthedocs.io/en/latest/_images/potjans_2014_box_plot.png" width="400"/> |
+| <img src="figures/potjans_2014_microcircuit.png" width="300"/> | <img src="figures/potjans_2014_raster_plot.png" width="400"/> | <img src="figures/potjans_2014_box_plot.png" width="400"/> |
 
 *Sketch of the cortical microcircuit model (left), spiking activity (middle) and distributions of time averaged single-neuron firing rates across neurons in each subpopulation (right). Adapted from ([van Albada et al., 2018](https://doi.org/10.3389/fnins.2018.00291))*
 

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -22,7 +22,7 @@ a.md-tabs__link, a.md-source {
  }
 
 .md-typeset table:not([class]) th {
-  background-color: #fff;
+  background-color: #ededed;
   color: black;
 }
 .md-typeset table:not([class]) th {

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -23,6 +23,11 @@ a.md-tabs__link, a.md-source {
 
 .md-typeset table:not([class]) th {
   background-color: #fff;
+  color: black;
+}
+.md-typeset table:not([class]) th {
+	/* color: #fff; */
+	vertical-align: top;
 }
 
 /* To add matching styling for the header in index.html */

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -25,10 +25,6 @@ a.md-tabs__link, a.md-source {
   background-color: #ededed;
   color: black;
 }
-.md-typeset table:not([class]) th {
-	/* color: #fff; */
-	vertical-align: top;
-}
 
 /* To add matching styling for the header in index.html */
 div[role="main"] .md-header {


### PR DESCRIPTION
Applying the same logic as was done with the PDF (#41 ) to the images for the README
So the path on GitHub is `figures/` and on Read the Docs this is changed to `docs/_static/images` and the path is replaced in the file at build time.