### PR TITLE
Update publications.bib and adjust uses_PD14 tags

### DIFF
--- a/docs/publications/publications.bib
+++ b/docs/publications/publications.bib
@@ -344,7 +344,6 @@
   author={Pronold, Jari and Morales-Gregorio, Aitor and Rostami, Vahid and van Albada, Sacha J.},
   year={2024},
   month=jan,
-  journal={bioRxiv},
   uses_PD14 = {yes}
 }
 
@@ -3957,7 +3956,7 @@
   uses_PD14 = {no}
 }
 
-@article{moreni2025b,
+@article{moreni2025,
   title        = {Cell-type-specific firing patterns in a V1 cortical column model depend on feedforward and feedback-driven states},
   author       = {Giulia Moreni and Rares A Dorcioman and Cyriel M. A. Pennartz and Jorge F. Mejías},
   year         = {2025},
@@ -4013,12 +4012,6 @@
   uses_PD14 = {no}
 }
 
-
-#############################
-##### NEW PUBLICATIOONS #####
-#############################
-
-
 @article{Iqbal_2025,
   title = {Biologically grounded neocortex computational primitives implemented on neuromorphic hardware improve vision transformer performance},
   author = {Asim Iqbal and Hassan Mahmood and Greg J. Stuart and Gord Fishell and Suraj Honnuraiah},
@@ -4030,7 +4023,7 @@
   publication_date = {2025-10-07},
   doi = {10.1073/pnas.2504164122},
   url = {https://doi.org/10.1073/pnas.2504164122},
-  uses_PD14 = {}
+  uses_PD14 = {no}
 }
 
 @article{Chen_2025,
@@ -4044,7 +4037,7 @@
   publication_date = {2025-08-26},
   doi = {10.3389/frai.2025.1605706},
   url = {https://doi.org/10.3389/frai.2025.1605706},
-  uses_PD14 = {}
+  uses_PD14 = {no}
 }
 
 @article{Evers_2025,
@@ -4058,7 +4051,7 @@
   publication_date = {2025-10-22},
   doi = {10.1038/s41598-025-20811-2},
   url = {https://doi.org/10.1038/s41598-025-20811-2},
-  uses_PD14 = {}
+  uses_PD14 = {no}
 }
 
 @article{Alegre-Cortés_2025,
@@ -4073,7 +4066,7 @@
   pages = {113213--113213},
   doi = {10.1016/j.isci.2025.113213},
   url = {https://doi.org/10.1016/j.isci.2025.113213},
-  uses_PD14 = {}
+  uses_PD14 = {no}
 }
 
 @article{Lee_2025,
@@ -4088,5 +4081,5 @@
   pages = {e1013469--e1013469},
   doi = {10.1371/journal.pcbi.1013469},
   url = {https://doi.org/10.1371/journal.pcbi.1013469},
-  uses_PD14 = {}
+  uses_PD14 = {no}
 }


### PR DESCRIPTION
The updated bibliography includes publications from 2025 and tracks which works directly implement the PD14 model and which merely refer to it.