### PR TITLE
Fix broken links in performance benchmarks

### DIFF
--- a/docs/benchmarking/_scripts/visualize_performance.py
+++ b/docs/benchmarking/_scripts/visualize_performance.py
@@ -106,8 +106,9 @@ def export_latex(data):
         inplace=True,
     )
 
-    os.system("mkdir -p figures")
-    fname = "figures/performance_summary.tex"
+    figures_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "figures")
+    os.makedirs(figures_dir, exist_ok=True)
+    fname = os.path.join(figures_dir, "performance_summary.tex")
     df.to_latex(
         index=False,
         float_format="%g",
@@ -115,7 +116,7 @@ def export_latex(data):
         formatters={r"\#Nodes": int, r"Process size (nm)": int},
         buf=fname,
     )
-    fname = "figures/performance_summary.md"
+    fname = os.path.join(figures_dir, "performance_summary.md")
     df.to_markdown(
         index=False,
         # float_format="%g",

--- a/docs/benchmarking/benchmarking.md
+++ b/docs/benchmarking/benchmarking.md
@@ -9,7 +9,7 @@ The statistics (dark cyan curve) of the simulated activity (dark cyan dots) is c
 
 ## Performance data of different computing platforms
 
-:::{figure} figures/performance_summary.png
+:::{figure} ../_static/images/performance_summary.png
 :width: 800px
 
 Progress of the community in reduction of time to solution and energy consumption for the PD14 model. Colors group
@@ -18,7 +18,7 @@ individual studies. (a) Ratio between time passed on wall-clock and stretch of t
 year of publication in semi logarithmic representation. (b) Real-time factor as a function of energy per synaptic event in double
 logarithmic representation. Dashed line from fit through all data points with a slope of one. (c) Real-time factor versus process
 node in double logarithmic representation. Dashed line from fit through CPU and GPU data points with a slope of two. Citations
-of studies and values are given in this [table](figures/performance_summary.md). Figure from [(Senk et al., 2026)][1].
+of studies and values are given in this {download}`table <figures/performance_summary.md>`. Figure from [(Senk et al., 2026)][1].
 :::
 
 ## Benchmarking recipe

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,7 @@ sys.path.insert(0, str(Path('..', 'PyNEST/src').resolve()))
 # -- Run publication processing scripts --------------------------------------
 # Add docs directory to path so we can import _scripts
 sys.path.insert(0, str(Path(__file__).parent.resolve()))
+sys.path.insert(0, str(Path(__file__).parent / "benchmarking" / "_scripts"))
 
 nb_source = Path(__file__).parent.parent / "PyNEST/examples/microcircuit_example.ipynb"
 nb_dest = Path(__file__).parent / "microcircuit_example.ipynb"


### PR DESCRIPTION
fixes #75 
Apologies @tomtetzlaff @jhnnsnk I think this is my fault due to some confusion as to which figures were autogenerated and needed overview.
This should work now, the table is now a downloadable link, since the source page is gone.